### PR TITLE
Patch for esc key

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-core-search-assistant-plugin",
 	"name": "Core Search Assistant",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"minAppVersion": "0.15.6",
 	"description": "Enhance built-in search: keyboard interface, card preview, bigger preview",
 	"author": "qawatake",

--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -612,7 +612,8 @@ export class Controller extends obsidian.Component {
 				new Notice('Copy wiki link!');
 			});
 		});
-		scope.register([], 'Escape', () => {
+		scope.register([], 'Escape', (evt) => {
+			evt.preventDefault(); // to prevent esc key from triggering callback to clear the input form, which was introduced in Obsidian v0.15.6.
 			this.exit();
 		});
 


### PR DESCRIPTION
Fix a problem that you must press the esc key twice to exit the search mode in Obsidian v0.15.6.