### PR TITLE
Fix e2e cleanup against current Obsidian (refs #81)

### DIFF
--- a/tests/e2e-setup/cleanup.ts
+++ b/tests/e2e-setup/cleanup.ts
@@ -35,6 +35,8 @@ test("テスト用vaultの登録を解除する", async () => {
 
   // vault chooserを開く。コマンド名がObsidianのバージョンによって変わる
   // ("Open another vault" -> "Manage vaults...") ため、安定しているid経由で実行する
+  // @ts-expect-error app is a global in the Obsidian renderer
+  await window.waitForFunction(() => window.app?.commands != null);
   await window.evaluate(() => {
     // @ts-expect-error app is a global in the Obsidian renderer
     window.app.commands.executeCommandById("app:open-vault");

--- a/tests/e2e-setup/cleanup.ts
+++ b/tests/e2e-setup/cleanup.ts
@@ -33,16 +33,12 @@ test.afterEach(async () => {
 test("テスト用vaultの登録を解除する", async () => {
   let window = await app.firstWindow();
 
-  // コマンド "Open another vault"を実行
-  {
-    // コマンドパレットを開く
-    await window.getByLabel("Open command palette", { exact: true }).click();
-
-    // コマンドパレットに入力
-    const commandPalette = window.locator(":focus");
-    await commandPalette.fill("open another vault");
-    await commandPalette.press("Enter");
-  }
+  // vault chooserを開く。コマンド名がObsidianのバージョンによって変わる
+  // ("Open another vault" -> "Manage vaults...") ため、安定しているid経由で実行する
+  await window.evaluate(() => {
+    // @ts-expect-error app is a global in the Obsidian renderer
+    window.app.commands.executeCommandById("app:open-vault");
+  });
 
   // 新規windowが開くまで待つ
   window = await app.waitForEvent("window", (w) => w.url().includes("starter"));

--- a/tests/e2e-setup/cleanup.ts
+++ b/tests/e2e-setup/cleanup.ts
@@ -42,8 +42,12 @@ test("テスト用vaultの登録を解除する", async () => {
     window.app.commands.executeCommandById("app:open-vault");
   });
 
-  // 新規windowが開くまで待つ
-  window = await app.waitForEvent("window", (w) => w.url().includes("starter"));
+  // vault chooserウィンドウを待つ。waitForEvent("window")だとリスナー登録前に
+  // ウィンドウが開いた場合を取りこぼすため、app.windows()をポーリングする
+  await expect
+    .poll(() => app.windows().some((w) => w.url().includes("starter")))
+    .toBe(true);
+  window = app.windows().find((w) => w.url().includes("starter"))!;
 
   // もともと開いていたウィンドウを閉じる
   {


### PR DESCRIPTION
Obsidian renamed the app:open-vault command from "Open another vault"
to "Manage vaults...", so the command-palette text search silently
matched nothing and the test timed out waiting for the starter window.
Execute the command by its stable id instead of driving the palette.
