### PR TITLE
e2e: download the newest Obsidian release that ships a dmg

### DIFF
--- a/scripts/setup-obsidian.sh
+++ b/scripts/setup-obsidian.sh
@@ -59,8 +59,8 @@ else
   fi
 
   echo "⏬ Downloading Obsidian ($tag) dmg via gh CLI"
-  gh release download -R obsidianmd/obsidian-releases \
-    --pattern "$pattern" --dir "$tmp_dir" --tag "$tag"
+  gh release download "$tag" -R obsidianmd/obsidian-releases \
+    --pattern "$pattern" --dir "$tmp_dir"
 
   dmg_path="$(find "$tmp_dir" -name '*.dmg' -type f | head -n1)"
   [[ -n "$dmg_path" ]] || { echo "❌ .dmg が見つかりません" >&2; exit 1; }

--- a/scripts/setup-obsidian.sh
+++ b/scripts/setup-obsidian.sh
@@ -46,14 +46,21 @@ else
   version="${OBSIDIAN_VERSION:-latest}"
   pattern="Obsidian-*.dmg"
 
-  echo "⏬ Downloading Obsidian ($version) dmg via gh CLI"
   if [[ "$version" == "latest" ]]; then
-    gh release download -R obsidianmd/obsidian-releases \
-      --pattern "$pattern" --dir "$tmp_dir"
+    # The newest release does not always ship desktop assets (e.g. a mobile-only
+    # release carries just an .apk), so pick the newest stable release that
+    # actually has a macOS dmg instead of trusting GitHub's "latest".
+    tag="$(gh api "repos/obsidianmd/obsidian-releases/releases?per_page=30" \
+      --jq "[.[] | select(.draft | not) | select(.prerelease | not)
+             | select(any(.assets[].name; test(\"^Obsidian-.*\\\\.dmg$\")))][0].tag_name // empty")"
+    [[ -n "$tag" ]] || { echo "❌ no stable release with a macOS dmg found" >&2; exit 1; }
   else
-    gh release download -R obsidianmd/obsidian-releases \
-      --pattern "$pattern" --dir "$tmp_dir" --tag "v${version}"
+    tag="v${version}"
   fi
+
+  echo "⏬ Downloading Obsidian ($tag) dmg via gh CLI"
+  gh release download -R obsidianmd/obsidian-releases \
+    --pattern "$pattern" --dir "$tmp_dir" --tag "$tag"
 
   dmg_path="$(find "$tmp_dir" -name '*.dmg' -type f | head -n1)"
   [[ -n "$dmg_path" ]] || { echo "❌ .dmg が見つかりません" >&2; exit 1; }


### PR DESCRIPTION
## Why
`setup-obsidian.sh --ci` relied on GitHub's *latest* release, but that release is not guaranteed to carry desktop assets. Obsidian v1.13.8 (2026-08-21) ships only an `.apk`, so `gh release download --pattern 'Obsidian-*.dmg'` failed with *no assets match the file pattern* and the e2e jobs went red.

## What
When `OBSIDIAN_VERSION` is unset, resolve the tag explicitly: newest non-draft, non-prerelease release in `obsidianmd/obsidian-releases` that has an `Obsidian-*.dmg` asset (currently v1.13.7). An explicit `OBSIDIAN_VERSION` still works as before.

Verified locally that the resolution snippet returns `v1.13.7`.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8