### PR TITLE
ci: pin GitHub Actions to commit SHAs with pinact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           version: 2024.11.3
           install: true
@@ -28,8 +28,8 @@ jobs:
   e2e:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           version: 2024.11.3
           install: true
@@ -44,8 +44,8 @@ jobs:
   test-e2e-tools:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           version: 2024.11.3
           install: true

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -12,11 +12,11 @@ jobs:
     outputs:
       tagpr-tag: ${{ steps.tagpr.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - id: tagpr
-        uses: Songmu/tagpr@v1
+        uses: Songmu/tagpr@d1b8138b7a31075141b6cd64103de9485ced7ac9 # v1.20.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release:
@@ -26,8 +26,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           version: 2024.11.3
           install: true
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         run: pnpm build
       - name: Upload build artifact to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             main.js

--- a/mise.toml
+++ b/mise.toml
@@ -1,17 +1,20 @@
 [tools]
 node = "22"
 pnpm = "10.9"
-pinact = "4.1.1"
 
 # Pin GitHub Actions to commit SHAs so a re-pointed tag can't run code we never reviewed.
+# pinact is scoped to these tasks (not [tools]) so CI's `mise install` doesn't pull it in.
 [tasks.pin-actions]
 description = "Pin GitHub Actions in .github/workflows to commit SHAs"
+tools = { pinact = "4.1.1" }
 run = "pinact run"
 
 [tasks."pin-actions:update"]
 description = "Update pinned GitHub Actions to their latest versions (keeps SHA pins)"
+tools = { pinact = "4.1.1" }
 run = "pinact run --update"
 
 [tasks."pin-actions:check"]
 description = "Fail if any GitHub Action is not pinned to a commit SHA"
+tools = { pinact = "4.1.1" }
 run = "pinact run --check"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,17 @@
 [tools]
 node = "22"
 pnpm = "10.9"
+pinact = "4.1.1"
+
+# Pin GitHub Actions to commit SHAs so a re-pointed tag can't run code we never reviewed.
+[tasks.pin-actions]
+description = "Pin GitHub Actions in .github/workflows to commit SHAs"
+run = "pinact run"
+
+[tasks."pin-actions:update"]
+description = "Update pinned GitHub Actions to their latest versions (keeps SHA pins)"
+run = "pinact run --update"
+
+[tasks."pin-actions:check"]
+description = "Fail if any GitHub Action is not pinned to a commit SHA"
+run = "pinact run --check"


### PR DESCRIPTION
## Why
Mutable tags (`@v4`, `@v2`, …) can be re-pointed by whoever controls the action repo — that is exactly how tj-actions/changed-files was weaponised in 2025-03. Three of the four actions used here are maintained by individuals and two of them hold `contents: write`. Pinning to a full commit SHA means a compromised tag cannot run unreviewed code with our `GITHUB_TOKEN`.

## What
- Every `uses:` in `.github/workflows` is pinned to a 40-char SHA with the version kept in a trailing comment (pinact format, understood by Renovate/Dependabot).
- [pinact](https://github.com/suzuki-shunsuke/pinact) 4.1.1 is declared per-task in `mise.toml` (`tools = { pinact = … }`), **not** in `[tools]`, so CI's `mise install` does not download it. Tasks:
  - `mise run pin-actions` — (re)pin anything unpinned
  - `mise run pin-actions:update` — bump pinned actions to their latest release, keeping SHA pins
  - `mise run pin-actions:check` — fail if anything is unpinned
- `softprops/action-gh-release@v1` → `@v2` before pinning: the `v1` tag still resolves to v0.1.15; v2 is the maintained line and the inputs used (`files`, `tag_name`, `token`) are unchanged.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8