### PR TITLE
ci: run on pull_request/push and weekly schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 name: ci
 on:
   workflow_dispatch:
-#  pull_request:
-#  push:
-#    branches: ["main"]
-#  schedule:
-#    - cron: "0 18 * * *" # JST 3:00（UTC 18:00）
+  pull_request:
+  push:
+    branches: ["main"]
+  schedule:
+    # Weekly, Monday 06:00 JST (Sunday 21:00 UTC): catch breakage from new Obsidian releases.
+    - cron: "0 21 * * 0"
 
 permissions:
   contents: read


### PR DESCRIPTION
## What
- `pull_request` and `push` (main) triggers enabled
- `schedule`: weekly, Monday 06:00 JST (`0 21 * * 0` UTC)

## Why
The triggers were trimmed to `workflow_dispatch` while supply-chain hardening landed. That is done now (least-privilege `permissions`, `--frozen-lockfile`, SHA-pinned actions via pinact, dmg-aware Obsidian download), so a scheduled run no longer resolves anything mutable except the Obsidian release itself — which is the point: catch breakage from new Obsidian versions without waiting for a code change.

Weekly instead of daily: Obsidian ships every 1–2 weeks, and the e2e suite still has a flaky test; a daily red run would train us to ignore it. Bump to daily once e2e is stable.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8