### PR TITLE
ci: bump pinned mise to 2026.8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
-          version: 2024.11.3
+          version: 2026.8.3
           install: true
           cache: true # [default: true] cache mise using GitHub's cache
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
-          version: 2024.11.3
+          version: 2026.8.3
           install: true
           cache: true
       - run: pnpm install
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
-          version: 2024.11.3
+          version: 2026.8.3
           install: true
           cache: true
       - run: pnpm install

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
-          version: 2024.11.3
+          version: 2026.8.3
           install: true
           cache: true # [default: true] cache mise using GitHub's cache
       - name: Install dependencies


### PR DESCRIPTION
`jdx/mise-action` pins mise itself to **2024.11.3**, which is now too old in two ways:

1. **It breaks the Dependabot bump to mise-action v4** (`mise env --dotenv` is not understood by that mise → `unexpected argument '--dotenv'`).
2. **It installs pnpm by git-cloning a third-party asdf plugin** (`jonathanmorley/asdf-pnpm`) on every run. Current mise installs pnpm through the aqua / npm backend (checksummed release artifacts), which is what the rest of our supply-chain setup assumes.

Bump to **2026.8.3** (released 2026-08-07, > 7 days old). Also makes mise understand the per-task `tools` field (the `unknown field` warnings go away).

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8
