### PR TITLE
ci: run lint in CI (and build on every PR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,9 @@ jobs:
           version: 2026.8.3
           install: true
           cache: true # [default: true] cache mise using GitHub's cache
-      - name: Install dependencies
-        run: pnpm install
-      - name: Build
-        run: pnpm build
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm build
 
   e2e:
     runs-on: macos-latest
@@ -35,7 +34,7 @@ jobs:
           version: 2026.8.3
           install: true
           cache: true
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: ./scripts/setup-obsidian.sh --ci
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -51,7 +50,7 @@ jobs:
           version: 2026.8.3
           install: true
           cache: true
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: ./scripts/setup-obsidian.sh --ci
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Lint (Biome) was not enforced in any CI, and this repo only ran build. Now every PR and push to main runs `pnpm install --frozen-lockfile` → `pnpm lint` → `pnpm build`.

Motivation beyond style: a package.json with leftover merge-conflict markers made it into a PR branch earlier today (caught by CI only in repos that had one). `--frozen-lockfile` install and Biome fail fast on that.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8