### PR TITLE
ci: add release guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -34,6 +34,8 @@ jobs:
           cache: true # [default: true] cache mise using GitHub's cache
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
       - name: Build
         run: pnpm build
       - name: Upload build artifact to release


### PR DESCRIPTION
## Summary
- cancel stale pull_request CI runs when a newer run starts
- run lint in the release job before building and uploading release assets

## Verification
- git diff --check