### PR TITLE
ci: align e2e commands with pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm e2e:setup
-      - run: pnpm e2e
+      - run: pnpm e2e:test
 
   test-e2e-tools:
     runs-on: macos-latest

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
 		"sass-build": "sass --no-source-map *.scss styles.css",
 		"esbuild": "node esbuild.config.mjs production",
 		"build": "pnpm esbuild && pnpm sass-build",
-		"e2e:setup": "npx playwright test tests/e2e-setup/setup.ts --project e2e-setup",
+		"e2e:setup": "playwright test tests/e2e-setup/setup.ts --project e2e-setup",
 		"e2e:cleanup": "playwright test tests/e2e-setup/cleanup.ts --project e2e-setup",
-		"e2e": "npm run build && playwright test --project e2e"
+		"e2e:test": "playwright test --project e2e",
+		"e2e": "pnpm build && pnpm e2e:test"
 	},
 	"keywords": [],
 	"author": "",

--- a/scripts/setup-obsidian.sh
+++ b/scripts/setup-obsidian.sh
@@ -104,7 +104,7 @@ fi
 # ------------------------------------------------------------------------------
 echo "🔓 Unpacking $obsidian_app → $unpacked_path"
 rm -rf "$unpacked_path"
-npx --yes @electron/asar extract \
+pnpm exec asar extract \
     "$obsidian_app/Contents/Resources/app.asar" "$unpacked_path"
 cp "$obsidian_app/Contents/Resources/obsidian.asar" \
    "$unpacked_path/obsidian.asar"
@@ -115,12 +115,13 @@ echo "✅ Obsidian unpacked"
 # 4. プラグインをビルドして Vault にリンク
 # ------------------------------------------------------------------------------
 echo "🔧 Building plugin…"
-npm run build --silent
+pnpm build --silent
 echo "✅ Build done."
 
 echo "🔗 Linking plugin → $plugin_path"
 mkdir -p "$plugin_path"
 ln -fs "$root_path/manifest.json" "$plugin_path/manifest.json"
 ln -fs "$root_path/main.js"       "$plugin_path/main.js"
+ln -fs "$root_path/styles.css"    "$plugin_path/styles.css"
 
 echo "🎉 setup-obsidian.sh finished!"

--- a/scripts/setup-obsidian.sh
+++ b/scripts/setup-obsidian.sh
@@ -115,7 +115,7 @@ echo "✅ Obsidian unpacked"
 # 4. プラグインをビルドして Vault にリンク
 # ------------------------------------------------------------------------------
 echo "🔧 Building plugin…"
-pnpm build --silent
+pnpm build
 echo "✅ Build done."
 
 echo "🔗 Linking plugin → $plugin_path"


### PR DESCRIPTION
## Summary
- replace npm/npx usage in E2E setup paths with pnpm-based commands
- add an e2e:test script so CI can avoid rebuilding after setup-obsidian.sh already built the plugin
- link styles.css into the E2E vault plugin directory so tests run closer to the release artifact layout

## Verification
- git diff --check
- pnpm exec asar --version
- pnpm e2e:test --list